### PR TITLE
Fix base branch matching for pull requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ let canOverwrite;
 let noRefAction;
 let setEmptyVars;
 
-function parseBranchName(ref) {
+function parseBranchName(ref, baseRef) {
   if (!ref) {
     switch (noRefAction) {
       case "error":
@@ -53,7 +53,7 @@ function parseBranchName(ref) {
       branchName = refSourceName;
       break;
     case "pull":
-      branchName = `!pr>${refSourceName}`;
+      branchName = `!pr>${baseRef}`;
       break;
     case "tags":
       branchName = "!tag";
@@ -150,7 +150,8 @@ function branchEnvVars(environmentVariables) {
     setEmptyVars = getInput("bevSetEmptyVars") === "true";
 
     const ref = environmentVariables.GITHUB_REF;
-    const branchName = parseBranchName(ref);
+    const baseRef = environmentVariables.GITHUB_BASE_REF;
+    const branchName = parseBranchName(ref, baseRef);
 
     parseEnvVarPossibilities(environmentVariables).forEach(
       ([name, possibleValues]) => {

--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,6 @@ function parseBranchName(ref) {
     case "heads":
       branchName = refSourceName;
       break;
-    case "pulls":
-      branchName = `!pr>${refSourceName}`;
-      break;
     case "pull":
       branchName = `!pr>${refSourceName}`;
       break;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -30,13 +30,11 @@ describe("parseBranchName", () => {
   });
 
   test("pull requests to !pr>basebranch", () => {
-    expect(parseBranchName("refs/pulls/basebranch")).toBe("!pr>basebranch");
     expect(parseBranchName("refs/pull/basebranch")).toBe("!pr>basebranch");
     expect(parseBranchName("refs/pull/branch/with/slashes")).toBe(
       "!pr>branch/with/slashes"
     );
 
-    expect(parseBranchName("refs/pulls/feature/*")).toBe("!pr>feature/*");
     expect(parseBranchName("refs/pull/feature/*")).toBe("!pr>feature/*");
   });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -30,12 +30,12 @@ describe("parseBranchName", () => {
   });
 
   test("pull requests to !pr>basebranch", () => {
-    expect(parseBranchName("refs/pull/basebranch")).toBe("!pr>basebranch");
-    expect(parseBranchName("refs/pull/branch/with/slashes")).toBe(
+    expect(parseBranchName("refs/pull/20/merge", "basebranch")).toBe("!pr>basebranch");
+    expect(parseBranchName("refs/pull/20/merge", "branch/with/slashes")).toBe(
       "!pr>branch/with/slashes"
     );
 
-    expect(parseBranchName("refs/pull/feature/*")).toBe("!pr>feature/*");
+    expect(parseBranchName("refs/pull/20/merge", "feature/*")).toBe("!pr>feature/*");
   });
 
   test("tags should resolve to !tag", () => {


### PR DESCRIPTION
For pull requests GITHUB_REF will have the format "refs/pull/<pr_number>/merge". This PR will change the behaviour to extract the base branch from GITHUB_BASE_REF

Code path to handle refs/pulls has also been removed, pulls was a typo so shouldn't be necessary. See here: https://github.com/github/docs/issues/15737

@iamtheyammer Should i also add code to check the availability of GITHUB_BASE_REF? Did you ever encounter situations in which GITHUB_REF was not defined?